### PR TITLE
Compatability for laravel-enum 2.2.0

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -5,8 +5,9 @@
 
 namespace SimpleSquid\Nova\Fields\Enum;
 
-use BenSampo\Enum\Rules\EnumValue;
 use Laravel\Nova\Fields\Select;
+use BenSampo\Enum\Rules\EnumValue;
+use Illuminate\Contracts\Support\Arrayable;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 class Enum extends Select
@@ -14,14 +15,14 @@ class Enum extends Select
     /**
      * Setup the Enum field with the Enum class.
      *
-     * @param  string  $class
+     * @param  string  $enumClass
      *
      * @return $this
      */
-    public function attachEnum($class)
+    public function attachEnum($enumClass)
     {
-        return $this->options(call_user_func($class . '::toSelectArray'))
-                    ->rules('required', new EnumValue($class, false))
+        return $this->options($this->getEnumOptions($enumClass))
+                    ->rules('required', new EnumValue($enumClass, false))
                     ->resolveUsing(
                         function ($enum) {
                             return $enum ? $enum->value : null;
@@ -47,5 +48,15 @@ class Enum extends Select
         if ($request->exists($requestAttribute)) {
             $model->{$attribute} = $request[$requestAttribute];
         }
+    }
+
+    protected function getEnumOptions(string $enumClass): array
+    {
+        // Since laravel-enum v2.2.0, the method has been named 'asSelectArray'
+        if (in_array(Arrayable::class, class_implements($enumClass))) {
+            return $enumClass::asSelectArray();
+        }
+
+        return $enumClass::toSelectArray();
     }
 }


### PR DESCRIPTION
I haven't said hello before, but I'd like to say thanks for making this package, I use it all the time in my projects.

I've just released an update to laravel-enum which affects your package. The method `toSelectArray` has been renamed to `asSelectArray`. https://github.com/BenSampo/laravel-enum/compare/v2.1.0...v2.2.0

This PR adds functionally to call the correct method depending on the version used so that it's compatible with both versions of laravel-enum.