### PR TITLE
Allow editing enums without casts

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -25,11 +25,11 @@ class Enum extends Select
                     ->rules('required', new EnumValue($enumClass, false))
                     ->resolveUsing(
                         function ($enum) {
-                            return $enum ? $enum->value : null;
+                            return $enum instanceof \BenSampo\Enum\Enum ? $enum->value : $enum;
                         })
                     ->displayUsing(
                         function ($enum) {
-                            return $enum ? $enum->description : null;
+                            return $enum instanceof \BenSampo\Enum\Enum ? $enum->description : $enum;
                         });
     }
 

--- a/tests/ExampleStringEnum.php
+++ b/tests/ExampleStringEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SimpleSquid\Nova\Fields\Enum\Tests;
+
+use BenSampo\Enum\Enum;
+
+/**
+ * @method static Administrator()
+ * @method static Moderator()
+ */
+class ExampleStringEnum extends Enum
+{
+    const Administrator = 'administrator';
+    const Moderator = 'moderator';
+}

--- a/tests/StringEnumTest.php
+++ b/tests/StringEnumTest.php
@@ -2,7 +2,6 @@
 
 namespace SimpleSquid\Nova\Fields\Enum\Tests;
 
-use BenSampo\Enum\Rules\EnumValue;
 use PHPUnit\Framework\TestCase;
 use SimpleSquid\Nova\Fields\Enum\Enum;
 

--- a/tests/StringEnumTest.php
+++ b/tests/StringEnumTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SimpleSquid\Nova\Fields\Enum\Tests;
+
+use BenSampo\Enum\Rules\EnumValue;
+use PHPUnit\Framework\TestCase;
+use SimpleSquid\Nova\Fields\Enum\Enum;
+
+class StringEnumTest extends TestCase
+{
+    /** @var \SimpleSquid\Nova\Fields\Enum\Enum */
+    private $field;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->field = Enum::make('Enum Field');
+
+        $this->field->attachEnum(ExampleStringEnum::class);
+    }
+
+    /** @test */
+    public function field_resolves_correct_value()
+    {
+        $this->field->resolve(['enum_field' => ExampleStringEnum::Moderator]);
+
+        $this->assertEquals('moderator', $this->field->value);
+    }
+
+    /** @test */
+    public function field_displays_correct_description()
+    {
+        $this->field->resolveForDisplay(['enum_field' => ExampleStringEnum::Moderator]);
+
+        $this->assertEquals('moderator', $this->field->value);
+    }
+}


### PR DESCRIPTION
We use 'enums' that are string values rather than ints (not really enums, but same idea). The app doesn't have casts set up because the strings are human-readable anyway, and I think with just a small tweak this package can work fine without casts.

One of the difficulties is we use enums on pivot tables to specify the nature or state of a relationship, and I think we'd have to create a pivot model for each of these in order to get the casts to work.