### PR TITLE
Improve PHPUnit fixtures and assert equals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.3
+  - 7.4
 
 env:
   matrix:

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -11,7 +11,7 @@ class EnumTest extends TestCase
     /** @var \SimpleSquid\Nova\Fields\Enum\Enum */
     private $field;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -50,7 +50,7 @@ class EnumTest extends TestCase
     {
         $this->field->resolve(['enum_field' => ExampleEnum::Moderator()]);
 
-        $this->assertEquals(1, $this->field->value);
+        $this->assertSame(1, $this->field->value);
     }
 
     /** @test */
@@ -58,6 +58,6 @@ class EnumTest extends TestCase
     {
         $this->field->resolveForDisplay(['enum_field' => ExampleEnum::Moderator()]);
 
-        $this->assertEquals('Moderator', $this->field->value);
+        $this->assertSame('Moderator', $this->field->value);
     }
 }

--- a/tests/StringEnumTest.php
+++ b/tests/StringEnumTest.php
@@ -10,7 +10,7 @@ class StringEnumTest extends TestCase
     /** @var \SimpleSquid\Nova\Fields\Enum\Enum */
     private $field;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -24,7 +24,7 @@ class StringEnumTest extends TestCase
     {
         $this->field->resolve(['enum_field' => ExampleStringEnum::Moderator]);
 
-        $this->assertEquals('moderator', $this->field->value);
+        $this->assertSame('moderator', $this->field->value);
     }
 
     /** @test */
@@ -32,6 +32,6 @@ class StringEnumTest extends TestCase
     {
         $this->field->resolveForDisplay(['enum_field' => ExampleStringEnum::Moderator]);
 
-        $this->assertEquals('moderator', $this->field->value);
+        $this->assertSame('moderator', $this->field->value);
     }
 }


### PR DESCRIPTION
# Changed log

- Add `php-7.4` for tests.
- According to the [PHPUnit documentation](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp`.
- Using the `assertSame` to replace `assertEquals` and it can make assert equals checking strict.