### PR TITLE
Ability to specify default value for filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `nova-enum-field` will be documented in this file.
 
+## Unreleased
+- Added ability to specify default value for `EnumFilter` and `EnumBooleanFilter`
+
 ## 2.3.0 - 2021-01-25
 
 - Drop support for Laravel `7.x`

--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ class Example extends Resource
 }
 ```
 
+To specify default value for `EnumFilter` or `EnumBooleanFilter` you may specify a third parameter:
+```php
+new EnumFilter('user_type', UserType::class, UserType::Administrator()),
+
+new EnumBooleanFilter('user_type', UserType::class, [
+    UserType::Administrator => true,
+    UserType::Moderator => true,
+    UserType::Subscriber => false,
+]),
+```
+
 ## Testing
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ class Example extends Resource
             // Or with optional filter name:
             (new EnumFilter('user_type', UserType::class))
                 ->name('Type of user'),
+                
+             // With optional default value:
+            (new EnumFilter('user_type', UserType::class))
+                ->default(UserType::Administrator),
         ];
     }
 }
@@ -140,9 +144,16 @@ class Example extends Resource
             
             new EnumBooleanFilter('user_permissions', UserPermissions::class),
             
-            // Or with optional filter name:
+            // With optional filter name:
             (new EnumBooleanFilter('user_type', UserType::class))
                 ->name('Type of user'),
+                
+            // With optional default values:
+            (new EnumBooleanFilter('user_type', UserType::class))
+                ->default([
+                    UserType::Administrator,
+                    UserType::Moderator,
+                ]),
             
             // When filtering a FlaggedEnum, it will default to filtering
             // by ANY flags, however you may wish to filter by ALL flags:
@@ -151,17 +162,6 @@ class Example extends Resource
         ];
     }
 }
-```
-
-To specify default value for `EnumFilter` or `EnumBooleanFilter` you may specify a third parameter:
-```php
-new EnumFilter('user_type', UserType::class, UserType::Administrator()),
-
-new EnumBooleanFilter('user_type', UserType::class, [
-    UserType::Administrator => true,
-    UserType::Moderator => true,
-    UserType::Subscriber => false,
-]),
 ```
 
 ## Testing

--- a/src/EnumBooleanFilter.php
+++ b/src/EnumBooleanFilter.php
@@ -22,11 +22,10 @@ class EnumBooleanFilter extends BooleanFilter
 
     protected $scope = 'any';
 
-    public function __construct($column, $class, $default = null)
+    public function __construct($column, $class)
     {
         $this->column = $column;
         $this->class = $class;
-        $this->default = $default;
 
         $this->flagged = is_subclass_of($this->class, \BenSampo\Enum\FlaggedEnum::class);
     }
@@ -96,10 +95,21 @@ class EnumBooleanFilter extends BooleanFilter
 
     public function default()
     {
+        if (isset(func_get_args()[0])) {
+            $this->default = collect(is_array(func_get_args()[0]) ? func_get_args()[0] : [func_get_args()[0]])
+                ->map(function ($value, $key) {
+                    return is_subclass_of($value, \BenSampo\Enum\Enum::class) ? $value->value : $value;
+                })->all();
+
+            return $this;
+        }
+
         if (is_null($this->default)) {
             return parent::default();
         }
 
-        return $this->default;
+        return collect($this->default)->mapWithKeys(function ($option) {
+                return [$option => true];
+            })->all() + parent::default();
     }
 }

--- a/src/EnumBooleanFilter.php
+++ b/src/EnumBooleanFilter.php
@@ -109,7 +109,7 @@ class EnumBooleanFilter extends BooleanFilter
         }
 
         return collect($this->default)->mapWithKeys(function ($option) {
-                return [$option => true];
-            })->all() + parent::default();
+            return [$option => true];
+        })->all() + parent::default();
     }
 }

--- a/src/EnumBooleanFilter.php
+++ b/src/EnumBooleanFilter.php
@@ -16,14 +16,17 @@ class EnumBooleanFilter extends BooleanFilter
 
     protected $class;
 
+    protected $default;
+
     protected $flagged;
 
     protected $scope = 'any';
 
-    public function __construct($column, $class)
+    public function __construct($column, $class, $default = null)
     {
         $this->column = $column;
         $this->class = $class;
+        $this->default = $default;
 
         $this->flagged = is_subclass_of($this->class, \BenSampo\Enum\FlaggedEnum::class);
     }
@@ -89,5 +92,14 @@ class EnumBooleanFilter extends BooleanFilter
         }
 
         return array_flip($this->class::asSelectArray());
+    }
+
+    public function default()
+    {
+        if (is_null($this->default)) {
+            return parent::default();
+        }
+
+        return $this->default;
     }
 }

--- a/src/EnumFilter.php
+++ b/src/EnumFilter.php
@@ -15,12 +15,15 @@ class EnumFilter extends Filter
 
     protected $class;
 
+    protected $default;
+
     protected $flagged;
 
-    public function __construct($column, $class)
+    public function __construct($column, $class, $default = null)
     {
         $this->column = $column;
         $this->class = $class;
+        $this->default = $default;
 
         $this->flagged = is_subclass_of($this->class, \BenSampo\Enum\FlaggedEnum::class);
     }
@@ -48,5 +51,14 @@ class EnumFilter extends Filter
     public function options(Request $request)
     {
         return array_flip($this->class::asSelectArray());
+    }
+
+    public function default()
+    {
+        if (is_null($this->default)) {
+            return parent::default();
+        }
+
+        return $this->default;
     }
 }

--- a/src/EnumFilter.php
+++ b/src/EnumFilter.php
@@ -19,11 +19,10 @@ class EnumFilter extends Filter
 
     protected $flagged;
 
-    public function __construct($column, $class, $default = null)
+    public function __construct($column, $class)
     {
         $this->column = $column;
         $this->class = $class;
-        $this->default = $default;
 
         $this->flagged = is_subclass_of($this->class, \BenSampo\Enum\FlaggedEnum::class);
     }
@@ -55,6 +54,12 @@ class EnumFilter extends Filter
 
     public function default()
     {
+        if (isset(func_get_args()[0])) {
+            $this->default = is_subclass_of(func_get_args()[0], \BenSampo\Enum\Enum::class) ? func_get_args()[0]->value : func_get_args()[0];
+
+            return $this;
+        }
+
         if (is_null($this->default)) {
             return parent::default();
         }

--- a/tests/Filters/BooleanFilterTest.php
+++ b/tests/Filters/BooleanFilterTest.php
@@ -11,11 +11,18 @@ class BooleanFilterTest extends TestCase
 {
     private $filter;
 
+    private $emptyFilter;
+
     private $mockFilter;
 
     protected function setUp(): void
     {
-        $this->filter = new EnumBooleanFilter('enum', IntegerEnum::class);
+        $this->filter = new EnumBooleanFilter('enum', IntegerEnum::class, [
+            IntegerEnum::Administrator => true,
+            IntegerEnum::Moderator => true,
+            IntegerEnum::Subscriber => false,
+        ]);
+        $this->emptyFilter = new EnumBooleanFilter('enum', IntegerEnum::class);
 
         $this->mockFilter = new MockFilter($this->filter);
     }
@@ -38,5 +45,25 @@ class BooleanFilterTest extends TestCase
         $this->assertInstanceOf(EnumBooleanFilter::class, $this->filter->name('Different name'));
 
         $this->assertEquals('Different name', $this->filter->name());
+    }
+
+    /** @test */
+    public function it_has_a_default_value()
+    {
+        $this->assertEquals([
+            IntegerEnum::Administrator => true,
+            IntegerEnum::Moderator => true,
+            IntegerEnum::Subscriber => false,
+        ], $this->filter->jsonSerialize()['currentValue']);
+    }
+
+    /** @test */
+    public function it_should_have_all_false_value_if_no_default_specified()
+    {
+        $this->assertEquals([
+            IntegerEnum::Administrator => false,
+            IntegerEnum::Moderator => false,
+            IntegerEnum::Subscriber => false,
+        ], $this->emptyFilter->jsonSerialize()['currentValue']);
     }
 }

--- a/tests/Filters/BooleanFilterTest.php
+++ b/tests/Filters/BooleanFilterTest.php
@@ -11,18 +11,11 @@ class BooleanFilterTest extends TestCase
 {
     private $filter;
 
-    private $emptyFilter;
-
     private $mockFilter;
 
     protected function setUp(): void
     {
-        $this->filter = new EnumBooleanFilter('enum', IntegerEnum::class, [
-            IntegerEnum::Administrator => true,
-            IntegerEnum::Moderator => true,
-            IntegerEnum::Subscriber => false,
-        ]);
-        $this->emptyFilter = new EnumBooleanFilter('enum', IntegerEnum::class);
+        $this->filter = new EnumBooleanFilter('enum', IntegerEnum::class);
 
         $this->mockFilter = new MockFilter($this->filter);
     }
@@ -48,22 +41,43 @@ class BooleanFilterTest extends TestCase
     }
 
     /** @test */
-    public function it_has_a_default_value()
+    public function it_accepts_optional_default_values()
     {
+        $this->filter->default(IntegerEnum::Moderator);
+
         $this->assertEquals([
-            IntegerEnum::Administrator => true,
+            IntegerEnum::Administrator => false,
             IntegerEnum::Moderator => true,
             IntegerEnum::Subscriber => false,
+        ], $this->filter->jsonSerialize()['currentValue']);
+
+        $this->filter->default(IntegerEnum::Administrator());
+
+        $this->assertEquals([
+                                IntegerEnum::Administrator => true,
+                                IntegerEnum::Moderator => false,
+                                IntegerEnum::Subscriber => false,
+                            ], $this->filter->jsonSerialize()['currentValue']);
+
+        $this->filter->default([
+           IntegerEnum::Subscriber,
+           IntegerEnum::Moderator(),
+       ]);
+
+        $this->assertEquals([
+            IntegerEnum::Administrator => false,
+            IntegerEnum::Moderator => true,
+            IntegerEnum::Subscriber => true,
         ], $this->filter->jsonSerialize()['currentValue']);
     }
 
     /** @test */
-    public function it_should_have_all_false_value_if_no_default_specified()
+    public function it_has_no_default_value_by_default()
     {
         $this->assertEquals([
             IntegerEnum::Administrator => false,
             IntegerEnum::Moderator => false,
             IntegerEnum::Subscriber => false,
-        ], $this->emptyFilter->jsonSerialize()['currentValue']);
+        ], $this->filter->jsonSerialize()['currentValue']);
     }
 }

--- a/tests/Filters/FilterTest.php
+++ b/tests/Filters/FilterTest.php
@@ -11,14 +11,11 @@ class FilterTest extends TestCase
 {
     private $filter;
 
-    private $emptyFilter;
-
     private $mockFilter;
 
     protected function setUp(): void
     {
-        $this->filter = new EnumFilter('enum', IntegerEnum::class, IntegerEnum::Moderator());
-        $this->emptyFilter = new EnumFilter('enum', IntegerEnum::class);
+        $this->filter = new EnumFilter('enum', IntegerEnum::class);
 
         $this->mockFilter = new MockFilter($this->filter);
     }
@@ -44,14 +41,20 @@ class FilterTest extends TestCase
     }
 
     /** @test */
-    public function it_has_a_default_value()
+    public function it_accepts_an_optional_default_value()
     {
-        $this->assertEquals(IntegerEnum::Moderator(), $this->filter->jsonSerialize()['currentValue']);
+        $this->filter->default(IntegerEnum::Moderator);
+
+        $this->assertEquals(IntegerEnum::Moderator, $this->filter->jsonSerialize()['currentValue']);
+
+        $this->filter->default(IntegerEnum::Subscriber());
+
+        $this->assertEquals(IntegerEnum::Subscriber, $this->filter->jsonSerialize()['currentValue']);
     }
 
     /** @test */
-    public function it_shouldnt_have_a_value_if_no_default()
+    public function it_has_no_default_value_by_default()
     {
-        $this->assertEquals('', $this->emptyFilter->jsonSerialize()['currentValue']);
+        $this->assertEquals('', $this->filter->jsonSerialize()['currentValue']);
     }
 }

--- a/tests/Filters/FilterTest.php
+++ b/tests/Filters/FilterTest.php
@@ -11,11 +11,14 @@ class FilterTest extends TestCase
 {
     private $filter;
 
+    private $emptyFilter;
+
     private $mockFilter;
 
     protected function setUp(): void
     {
-        $this->filter = new EnumFilter('enum', IntegerEnum::class);
+        $this->filter = new EnumFilter('enum', IntegerEnum::class, IntegerEnum::Moderator());
+        $this->emptyFilter = new EnumFilter('enum', IntegerEnum::class);
 
         $this->mockFilter = new MockFilter($this->filter);
     }
@@ -38,5 +41,17 @@ class FilterTest extends TestCase
         $this->assertInstanceOf(EnumFilter::class, $this->filter->name('Different name'));
 
         $this->assertEquals('Different name', $this->filter->name());
+    }
+
+    /** @test */
+    public function it_has_a_default_value()
+    {
+        $this->assertEquals(IntegerEnum::Moderator(), $this->filter->jsonSerialize()['currentValue']);
+    }
+
+    /** @test */
+    public function it_shouldnt_have_a_value_if_no_default()
+    {
+        $this->assertEquals('', $this->emptyFilter->jsonSerialize()['currentValue']);
     }
 }


### PR DESCRIPTION
Closes https://github.com/simplesquid/nova-enum-field/issues/32

To specify a default value, the user shall specify the third argument to `EnumFilter`'s or `EnumBooleanFilter`'s constructor. The way of creating default value is the same as for `Filter` and `BooleanFilter` classes in nova. Specifying default value works for basic constraint referencing `UserType::Moderator` and static function call `UserType::Moderator()`. This is a non-breaking change, since the third parameter is optional. I've briefly tested this enhancement. I've also added a small example to README.

Thanks for creating a cool package!