### PR TITLE
v3 upgrade

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,6 +1,12 @@
 name: Check & fix styling
 
-on: [ push ]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   style:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,25 +9,15 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 7.3, 7.4, 8.0, 8.1 ]
-        laravel: [ "^8.0", "^9.0" ]
+        php: [ 8.0, 8.1 ]
+        laravel: [ "^9.0" ]
+        enum: [ "^5.0", "^6.0" ]
         stability: [ prefer-lowest, prefer-stable ]
-        exclude:
-          - php: 7.3
-            laravel: "^9.0"
-          - php: 7.4
-            laravel: "^9.0"
-          - php: 8.1
-            laravel: "^8.0"
         include:
-          - laravel: "^8.0"
-            testbench: "^6.0"
-            enum: "^4.0"
           - laravel: "^9.0"
             testbench: "^7.0"
-            enum: "^5.0"
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - E${{ matrix.enum }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     services:
       mysql:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,12 @@
 name: Run tests
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `nova-enum-field` will be documented in this file.
 
+## 3.0.0 - 2022-11-29
+- Add support for BenSampo/laravel-enum v6
+- Laravel v9 is now required
+- PHP 8.0 or higher is now required
+- BenSampo/laravel-enum v5 or higher is now required
+
+## 2.7.0 - 2022-04-27
+- Support Laravel Nova v4
+
+## 2.6.0 - 2022-02-22
+- Support Laravel v9
+- Support BenSampo/laravel-enum v5
+
+## 2.5.0 - 2021-12-20
+- Upgrade to v4 of BenSampo/laravel-enum
+
 ## 2.4.0 - 2021-10-24
 - Allow nullable Enum fields.
 - Fix filter issue when multiple enum filters are used.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Package skeleton based on [spatie/skeleton-php](https://github.com/spatie/skelet
 
 ## About us
 
-SimpleSquid is a small web development and design company based in Cape Town, South Africa.
+SimpleSquid is a small web development and design company based in Valkenburg, Netherlands.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,18 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "bensampo/laravel-enum": "^3.1|^4.0|^5.0",
-        "illuminate/support": "^8.0|^9.0",
+        "php": "^8.0",
+        "bensampo/laravel-enum": "^5.0|^6.0",
+        "illuminate/support": "^9.0",
         "laravel/nova": "^3.0|^4.0"
     },
     "require-dev": {
-        "joshgaber/novaunit": "^2.2",
+        "joshgaber/novaunit": "^3.0",
         "mockery/mockery": "^1.3.3",
-        "nunomaduro/collision": "^5.2|^6.1",
-        "orchestra/testbench": "^6.0|^7.0",
+        "nunomaduro/collision": "^6.1",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.3.3",
-        "symfony/var-dumper": "^5.0|^6.0"
+        "symfony/var-dumper": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -34,7 +34,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_allows_an_enum_to_be_attached()
     {
-        $this->assertArrayHasKey('options', $this->field->meta);
+        $this->assertObjectHasAttribute('optionsCallback', $this->field);
     }
 
     /** @test */
@@ -48,14 +48,9 @@ class FieldTest extends TestCase
     /** @test */
     public function it_displays_enum_options()
     {
-        $this->assertCount(count(IntegerEnum::getValues()), $this->field->meta['options']);
+        $this->assertCount(count(IntegerEnum::getValues()), $this->field->optionsCallback);
 
-        foreach (IntegerEnum::getValues() as $enum) {
-            $this->assertContains([
-                                      'label' => IntegerEnum::getDescription($enum),
-                                      'value' => $enum,
-                                  ], $this->field->meta['options']);
-        }
+        $this->assertSame(IntegerEnum::asSelectArray(), $this->field->optionsCallback);
     }
 
     /** @test */

--- a/tests/Fields/IntegerFieldTest.php
+++ b/tests/Fields/IntegerFieldTest.php
@@ -38,7 +38,7 @@ class IntegerFieldTest extends TestCase
     {
         $this->field->resolveForDisplay($this->model);
 
-        $this->assertSame(IntegerEnum::Moderator()->description, $this->field->displayedAs);
+        $this->assertSame(IntegerEnum::Moderator()->description, $this->field->displayedAs ?? $this->field->value);
     }
 
     /** @test */

--- a/tests/Fields/IntegerFieldTest.php
+++ b/tests/Fields/IntegerFieldTest.php
@@ -38,7 +38,7 @@ class IntegerFieldTest extends TestCase
     {
         $this->field->resolveForDisplay($this->model);
 
-        $this->assertSame(IntegerEnum::Moderator()->description, $this->field->value);
+        $this->assertSame(IntegerEnum::Moderator()->description, $this->field->displayedAs);
     }
 
     /** @test */

--- a/tests/Fields/StringFieldTest.php
+++ b/tests/Fields/StringFieldTest.php
@@ -38,7 +38,7 @@ class StringFieldTest extends TestCase
     {
         $this->field->resolveForDisplay($this->model);
 
-        $this->assertSame(StringEnum::Moderator()->description, $this->field->value);
+        $this->assertSame(StringEnum::Moderator()->description, $this->field->displayedAs);
     }
 
     /** @test */

--- a/tests/Fields/StringFieldTest.php
+++ b/tests/Fields/StringFieldTest.php
@@ -38,7 +38,7 @@ class StringFieldTest extends TestCase
     {
         $this->field->resolveForDisplay($this->model);
 
-        $this->assertSame(StringEnum::Moderator()->description, $this->field->displayedAs);
+        $this->assertSame(StringEnum::Moderator()->description, $this->field->displayedAs ?? $this->field->value);
     }
 
     /** @test */


### PR DESCRIPTION
- Add support for BenSampo/laravel-enum v6
- Laravel v9 is now required
- PHP 8.0 or higher is now required
- BenSampo/laravel-enum v5 or higher is now required